### PR TITLE
chore: Update lodash to v4.17.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,9 +2599,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.debounce": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "detect-character-encoding": "^0.6.0",
     "fs-extra": "^6.0.1",
     "http-server": "^0.11.1",
+    "lodash": "^4.17.11",
     "unzipper": "^0.8.14"
   },
   "peerDependencies": {


### PR DESCRIPTION
Resolving: Known low severity security vulnerability detected in lodash < 4.17.11